### PR TITLE
🎨 Palette: Accessibility for device preview buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tablet"
+                title="Vista de tablet"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>


### PR DESCRIPTION
This PR implements a micro-UX improvement by enhancing the accessibility of the device preview buttons in the editor header. These icon-only buttons were previously inaccessible to screen readers and had no visual focus indicators for keyboard users.

💡 **What:** Added `aria-label` and `title` attributes to the device preview buttons (Monitor, Tablet, Smartphone) and applied Tailwind's `focus-visible:ring-2` to provide clear keyboard focus.

🎯 **Why:** To ensure the interface is inclusive and navigable for all users, including those relying on assistive technologies or keyboard-only interaction.

♿ **Accessibility:**
- Screen readers now announce the purpose of each preview toggle.
- Keyboard users can clearly see which device view is focused.
- Visual titles provide helpful tooltips on hover.

*Note: This change is under 50 lines and focuses on a single UX improvement as per Palette's guidelines.*

---
*PR created automatically by Jules for task [14579482385171871457](https://jules.google.com/task/14579482385171871457) started by @satbmc*