### PR TITLE
🎨 Palette: Accessibility improvement for device switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista móvil"
+                title="Vista móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added `aria-label`, `title`, and `focus-visible` styles to the icon-only buttons in the preview device switcher.

### 🎯 Why: The user problem it solves
Icon-only buttons are often inaccessible to screen readers and lack visual focus indicators for keyboard users. Adding these attributes and styles ensures all users can identify and interact with these controls.

### ♿ Accessibility: Any a11y improvements made
- Added descriptive `aria-label` and `title` in Spanish.
- Implemented visible focus rings using Tailwind's `focus-visible` utility.
- Ensured keyboard navigation is intuitive by following standard focus patterns.

---
*PR created automatically by Jules for task [9125619272408991117](https://jules.google.com/task/9125619272408991117) started by @satbmc*