### PR TITLE
🎨 Palette: Improve accessibility and keyboard navigation for section list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - [Keyboard Accessibility for Hidden Elements]
+**Learning:** Elements hidden by `opacity-0` or similar styles for hover-only interactions remain invisible to keyboard users even when focused, unless specific focus-based visibility classes (`focus-visible:opacity-100`) are added. Additionally, interactive containers using only `onClick` must have `tabIndex`, `role`, and `onKeyDown` to be accessible.
+**Action:** Always pair hover-based visibility with `focus-visible` and `focus-within`. Ensure all custom interactive elements have semantic roles and keyboard listeners.
+
+## 2025-05-15 - [Constraint Adherence]
+**Learning:** Large file changes like `pnpm-lock.yaml` can easily mask small, high-quality UX improvements and violate strict line-count constraints.
+**Action:** Explicitly exclude lockfiles and build artifacts from commits when working on micro-UX tasks.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -630,8 +630,17 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
+                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer focus-within:border-indigo-400 focus-within:ring-1 focus-within:ring-indigo-400 focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                               onClick={() => setActiveSectionId(section.id)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  setActiveSectionId(section.id);
+                                }
+                              }}
+                              tabIndex={0}
+                              role="button"
+                              aria-pressed={activeSectionId === section.id}
                             >
                               <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
                                 {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Layout' && <Layout size={16} />}
@@ -648,7 +657,9 @@ export default function App() {
                               </span>
                               <button 
                                 onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                                aria-label="Eliminar sección"
+                                title="Eliminar sección"
+                                className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-red-500 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all outline-none"
                               >
                                 <Trash2 size={14} />
                               </button>


### PR DESCRIPTION
💡 What: Added ARIA labels and titles to the "Delete Section" button in the sidebar. Improved keyboard navigation for the entire section list.

🎯 Why: Previously, the delete button was only visible on hover and skipped during tab navigation. The section container itself was also not focusable, making the primary interaction inaccessible to keyboard-only users.

♿ Accessibility:
- Added `aria-label="Eliminar sección"` and `title="Eliminar sección"` to the trash button for screen readers and tooltips.
- Added `focus-within:border-indigo-400` and `focus-visible` classes to ensure the delete button is visible and has a clear focus ring during keyboard navigation.
- Added `tabIndex={0}`, `role="button"`, and an `onKeyDown` listener to the section container to allow it to be focused and "clicked" using the Enter or Space keys.
- All additions are localized in Spanish to match the rest of the interface.

📸 Verification: Visual verification confirmed the button becomes visible and highlighted when tabbing through the list. `pnpm lint` passed successfully.

---
*PR created automatically by Jules for task [7373169710006128969](https://jules.google.com/task/7373169710006128969) started by @satbmc*