### PR TITLE
🎨 Palette: Accessibility and Micro-UX Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,8 @@
+## 2025-05-14 - [Accessibility] Handling Nested Interactivity and Generic ARIA Labels
+
+**Learning:** When creating accessible "card" components or list items that are themselves interactive (e.g., using `role="button"` and `onKeyDown`), any nested interactive elements (like a "Delete" button) must explicitly stop event propagation for *both* click and keyboard events. Failing to stop `onKeyDown` propagation will cause the parent's keyboard handler to trigger even when the child is focused and activated. Additionally, list-based actions (like Delete) should always include the item's name in their `aria-label` to provide unique context for screen reader users in the "buttons list" view.
+
+**Action:**
+1. Use `e.stopPropagation()` in both `onClick` and `onKeyDown` for nested interactive elements.
+2. Ensure `aria-label` for repeated actions includes dynamic item-specific text: `aria-label={\`Eliminar sección: \${sectionName}\`}`.
+3. Always verify focus visibility with `focus-visible` utilities when elements are hidden by default on hover.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,18 +382,24 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
                 className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
                 className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
                 className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
@@ -630,8 +636,16 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
+                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer focus-within:opacity-100 focus-visible:ring-2 focus-visible:ring-indigo-500 outline-none ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                               onClick={() => setActiveSectionId(section.id)}
+                              tabIndex={0}
+                              role="button"
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  setActiveSectionId(section.id);
+                                }
+                              }}
                             >
                               <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
                                 {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Layout' && <Layout size={16} />}
@@ -648,7 +662,10 @@ export default function App() {
                               </span>
                               <button 
                                 onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                                onKeyDown={(e) => e.stopPropagation()}
+                                aria-label={`Eliminar sección: ${SECTION_TYPES.find(t => t.type === section.type)?.label}`}
+                                title={`Eliminar sección: ${SECTION_TYPES.find(t => t.type === section.type)?.label}`}
+                                className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
                               >
                                 <Trash2 size={14} />
                               </button>
@@ -691,28 +708,31 @@ export default function App() {
                         <div className="space-y-3">
                           <div className="flex items-center gap-3">
                             <input 
+                              id="primary-color"
                               type="color" 
                               value={pageData.theme.primaryColor} 
                               onChange={(e) => setPageData(prev => ({ ...prev, theme: { ...prev.theme, primaryColor: e.target.value } }))}
                               className="w-10 h-10 rounded-lg cursor-pointer"
                             />
-                            <span className="text-sm font-medium">Primario</span>
+                            <label htmlFor="primary-color" className="text-sm font-medium cursor-pointer">Primario</label>
                           </div>
                           <div className="flex items-center gap-3">
                             <input 
+                              id="secondary-color"
                               type="color" 
                               value={pageData.theme.secondaryColor} 
                               onChange={(e) => setPageData(prev => ({ ...prev, theme: { ...prev.theme, secondaryColor: e.target.value } }))}
                               className="w-10 h-10 rounded-lg cursor-pointer"
                             />
-                            <span className="text-sm font-medium">Secundario</span>
+                            <label htmlFor="secondary-color" className="text-sm font-medium cursor-pointer">Secundario</label>
                           </div>
                         </div>
                       </div>
 
                       <div>
-                        <label className="text-xs font-bold text-slate-400 uppercase tracking-wider block mb-3">Tipografía</label>
+                        <label htmlFor="font-family" className="text-xs font-bold text-slate-400 uppercase tracking-wider block mb-3">Tipografía</label>
                         <select 
+                          id="font-family"
                           value={pageData.theme.fontFamily}
                           onChange={(e) => setPageData(prev => ({ ...prev, theme: { ...prev.theme, fontFamily: e.target.value } }))}
                           className="w-full p-2 rounded-lg border border-slate-200 text-sm outline-none focus:ring-2 focus:ring-indigo-500"
@@ -755,8 +775,9 @@ export default function App() {
 
                       <div className="space-y-4">
                         <div>
-                          <label className="text-xs font-bold text-slate-500 mb-1 block">Tipo de Negocio</label>
+                          <label htmlFor="ai-business" className="text-xs font-bold text-slate-500 mb-1 block">Tipo de Negocio</label>
                           <input 
+                            id="ai-business"
                             type="text" 
                             placeholder="Ej: Agencia de viajes, SaaS de RRHH..."
                             className="w-full p-2 rounded-lg border border-slate-200 text-sm outline-none focus:ring-2 focus:ring-indigo-500"
@@ -765,8 +786,9 @@ export default function App() {
                           />
                         </div>
                         <div>
-                          <label className="text-xs font-bold text-slate-500 mb-1 block">Objetivo</label>
+                          <label htmlFor="ai-goal" className="text-xs font-bold text-slate-500 mb-1 block">Objetivo</label>
                           <input 
+                            id="ai-goal"
                             type="text" 
                             placeholder="Ej: Conseguir leads, vender curso..."
                             className="w-full p-2 rounded-lg border border-slate-200 text-sm outline-none focus:ring-2 focus:ring-indigo-500"
@@ -775,8 +797,9 @@ export default function App() {
                           />
                         </div>
                         <div>
-                          <label className="text-xs font-bold text-slate-500 mb-1 block">Público Objetivo</label>
+                          <label htmlFor="ai-audience" className="text-xs font-bold text-slate-500 mb-1 block">Público Objetivo</label>
                           <input 
+                            id="ai-audience"
                             type="text" 
                             placeholder="Ej: Emprendedores jóvenes, padres..."
                             className="w-full p-2 rounded-lg border border-slate-200 text-sm outline-none focus:ring-2 focus:ring-indigo-500"


### PR DESCRIPTION
### 💡 What: The UX enhancement added
This PR implements several micro-UX and accessibility improvements across the Landing Page Builder:
1.  **Accessible Preview Controls:** Added ARIA labels and descriptive titles to the Monitor, Tablet, and Smartphone view buttons.
2.  **Keyboard-Navigable Sidebar:** The section list in the "Diseño" tab is now fully keyboard-accessible. Each item is focusable and can be selected using Enter or Space keys.
3.  **Improved Action Context:** Section delete buttons now have unique ARIA labels that include the section name (e.g., "Eliminar sección: Cabecera (Hero)").
4.  **Nested Interactivity Fix:** Stopped keyboard event bubbling on delete buttons to prevent triggering the parent container's selection logic when deleting an item via keyboard.
5.  **Semantic Form Labels:** Associated labels with their respective inputs in the "Marca" and "IA" tabs using `id`/`htmlFor`.

### 🎯 Why: The user problem it solves
- Icon-only buttons were previously silent to screen readers.
- The section list was only interactive via mouse clicks.
- Form inputs were not easily focusable by clicking their labels, violating standard accessibility practices.
- Nested interactions caused conflicting actions during keyboard navigation.

### ♿ Accessibility: Any a11y improvements made
- Added `aria-label` and `title` to all icon-only buttons.
- Implemented `tabIndex={0}` and `role="button"` for interactive `div` elements.
- Ensured `focus-visible` states are clearly visible, even for elements that appear on hover.
- Corrected programmatic association of labels and inputs.
- Handled event propagation for nested interactive components.

### 📸 Screenshots
Visual focus states and label associations were verified via Playwright.

---
*Verified with `pnpm lint` and `pnpm build`.*

---
*PR created automatically by Jules for task [15356533504636057448](https://jules.google.com/task/15356533504636057448) started by @satbmc*