### PR TITLE
🎨 Palette: Improve Accessibility and Keyboard Navigation in Editor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Interactive Container Keyboard Accessibility
+**Learning:** When making non-semantic elements (like `div`) interactive via `onClick`, they must also be made keyboard-accessible using `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler. Importantly, to avoid double-triggers from nested buttons (which natively handle keyboard events), the container's `onKeyDown` should check if `e.target === e.currentTarget` or nested buttons must use `e.stopPropagation()`.
+**Action:** Always pair `onClick` on generic elements with ARIA roles and keyboard listeners, ensuring nested interactive elements are correctly handled to prevent event bubbling issues.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>
@@ -630,8 +636,17 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
+                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset focus-visible:outline-none ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                               onClick={() => setActiveSectionId(section.id)}
+                              role="button"
+                              tabIndex={0}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  if (e.target !== e.currentTarget) return;
+                                  e.preventDefault();
+                                  setActiveSectionId(section.id);
+                                }
+                              }}
                             >
                               <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
                                 {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Layout' && <Layout size={16} />}
@@ -648,7 +663,9 @@ export default function App() {
                               </span>
                               <button 
                                 onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                                aria-label="Eliminar sección"
+                                title="Eliminar sección"
+                                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
                               >
                                 <Trash2 size={14} />
                               </button>
@@ -977,8 +994,12 @@ export default function App() {
                         onClick={() => setActiveSectionId(section.id)}
                       >
                         {renderSectionPreview(section)}
-                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-2">
-                          <button className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600">
+                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex gap-2">
+                          <button
+                            aria-label="Configuración de sección"
+                            title="Configuración de sección"
+                            className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
+                          >
                             <Settings size={16} />
                           </button>
                         </div>


### PR DESCRIPTION
### 🎨 Palette: Micro-UX and Accessibility Improvements

#### 💡 What
This PR adds essential accessibility features to the Landing Page Editor, focusing on keyboard navigation and screen reader support.

#### 🎯 Why
The editor previously relied heavily on mouse interactions and hover states, making it difficult for keyboard users and screen reader users to manage page sections or toggle preview devices.

#### ♿ Accessibility Improvements
- **Icon-only Buttons:** Added `aria-label` and `title` to the Desktop/Tablet/Mobile preview buttons and the section Settings/Delete buttons.
- **Keyboard Navigation:** Converted the sidebar section list items into accessible buttons with proper roles and keyboard listeners.
- **Focus Visibility:** Added clear focus indicators (rings) and ensured that buttons normally hidden until hover are revealed when focused.
- **Localization:** All accessibility strings are provided in Spanish, maintaining consistency with the application's language.

#### 📸 Verification
Verified using Playwright by tabbing through the interface and ensuring focus states are visible and buttons are interactive via Enter/Space. Verified ARIA labels are present in the DOM.

---
*PR created automatically by Jules for task [9117467103583242552](https://jules.google.com/task/9117467103583242552) started by @satbmc*