### PR TITLE
🎨 Palette: Keyboard Accessibility for Sidebar Sections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-23 - Accessibility of Interactive Container Actions
+**Learning:** For elements hidden by default (like 'Delete' buttons appearing on hover), use Tailwind's `group-focus-within:opacity-100` on the child alongside `group` on the parent. This ensures keyboard users can see the action when they tab into the container. Additionally, avoid nesting interactive elements (e.g., a button inside a clickable div); use adjacent semantic buttons within a common container to ensure correct screen reader behavior and focus order.
+**Action:** Use the "common container with adjacent buttons" pattern for list items that have multiple actions, and always ensure hidden actions are revealed on focus.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -630,28 +630,36 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
-                              onClick={() => setActiveSectionId(section.id)}
+                              className={`group flex items-center rounded-xl border transition-all ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                             >
-                              <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Layout' && <Layout size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'CheckCircle' && <CheckCircle size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'MessageSquare' && <MessageSquare size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'CreditCard' && <CreditCard size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Image' && <ImageIcon size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'HelpCircle' && <HelpCircle size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Mail' && <Mail size={16} />}
-                                {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Type' && <Type size={16} />}
-                              </div>
-                              <span className="flex-1 font-medium text-sm truncate">
-                                {SECTION_TYPES.find(t => t.type === section.type)?.label}
-                              </span>
-                              <button 
-                                onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                              <button
+                                onClick={() => setActiveSectionId(section.id)}
+                                className="flex-1 flex items-center gap-3 p-3 rounded-l-xl text-left focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 focus-visible:outline-none"
                               >
-                                <Trash2 size={14} />
+                                <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Layout' && <Layout size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'CheckCircle' && <CheckCircle size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'MessageSquare' && <MessageSquare size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'CreditCard' && <CreditCard size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Image' && <ImageIcon size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'HelpCircle' && <HelpCircle size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Mail' && <Mail size={16} />}
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Type' && <Type size={16} />}
+                                </div>
+                                <span className="flex-1 font-medium text-sm truncate">
+                                  {SECTION_TYPES.find(t => t.type === section.type)?.label}
+                                </span>
                               </button>
+                              <div className="pr-2">
+                                <button
+                                  onClick={() => removeSection(section.id)}
+                                  aria-label="Eliminar sección"
+                                  title="Eliminar sección"
+                                  className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none focus-visible:opacity-100"
+                                >
+                                  <Trash2 size={14} />
+                                </button>
+                              </div>
                             </motion.div>
                           ))}
                         </AnimatePresence>


### PR DESCRIPTION
🎨 Palette here! I've added a micro-UX improvement to make the Landing Page Builder more accessible and intuitive.

💡 **What:** Improved the keyboard accessibility of the sidebar section list.
🎯 **Why:** Previously, sections could only be selected or deleted using a mouse. Now, keyboard users can navigate through the sections and their actions seamlessly.
♿ **Accessibility:**
- Replaced nested interactive elements with semantic, adjacent buttons.
- Added `aria-label` and `title` to the icon-only "Eliminar sección" button.
- Ensured that hidden actions (like the delete button) become visible when the parent container receives keyboard focus using `group-focus-within`.
- Added clear indigo and red focus rings for better visibility.

I've also recorded these patterns in `.Jules/palette.md` for future reference! 🎨✨

---
*PR created automatically by Jules for task [9143037631716404199](https://jules.google.com/task/9143037631716404199) started by @satbmc*