### PR TITLE
🎨 Palette: Accessible device preview buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Accessible Icon-Only Buttons
+**Learning:** Icon-only buttons in the editor (Monitor, Tablet, Smartphone) lacked descriptive labels for screen readers and visual tooltips, making them less intuitive and inaccessible.
+**Action:** Always add `aria-label` and `title` to icon-only buttons. Use Tailwind's `focus-visible` utility to ensure focus indicators are visible when navigating via keyboard.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>


### PR DESCRIPTION
The device preview buttons (Monitor, Tablet, Smartphone) in the Landing Page Builder were icon-only and lacked descriptive labels or focus indicators, which hindered accessibility and user intuition. 

This change adds:
- `aria-label` and `title` attributes for each button (localized in Spanish).
- `focus-visible` ring styles to provide clear visual feedback during keyboard navigation.

These micro-UX improvements make the editor more accessible and pleasant to use, following the project's design patterns and constraints.

---
*PR created automatically by Jules for task [6591481868778353096](https://jules.google.com/task/6591481868778353096) started by @satbmc*