### PR TITLE
🎨 Palette: Accessibility improvements for editor controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-26 - Keyboard Access for Hover-only Actions
+**Learning:** Found that critical section management actions (delete, settings) were hidden behind hover states, making them invisible and unreachable for keyboard-only users.
+**Action:** Use 'group-focus-within:opacity-100' on parent containers and 'focus-visible:opacity-100' on the interactive elements themselves to ensure they appear when tabbed into, combined with proper focus-visible rings for clear indication.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>
@@ -630,7 +636,7 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
+                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer focus-within:ring-2 focus-within:ring-indigo-500 focus-within:outline-none ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                               onClick={() => setActiveSectionId(section.id)}
                             >
                               <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
@@ -648,7 +654,9 @@ export default function App() {
                               </span>
                               <button 
                                 onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                                aria-label="Eliminar sección"
+                                title="Eliminar sección"
+                                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none focus-visible:opacity-100"
                               >
                                 <Trash2 size={14} />
                               </button>
@@ -977,8 +985,12 @@ export default function App() {
                         onClick={() => setActiveSectionId(section.id)}
                       >
                         {renderSectionPreview(section)}
-                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-2">
-                          <button className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600">
+                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex gap-2">
+                          <button
+                            aria-label="Configuración de sección"
+                            title="Configuración de sección"
+                            className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none focus-visible:opacity-100"
+                          >
                             <Settings size={16} />
                           </button>
                         </div>


### PR DESCRIPTION
### 💡 What
Added ARIA labels, titles, and improved keyboard navigation for core editor controls including:
- Device preview buttons (Monitor, Tablet, Smartphone)
- Section removal button in the sidebar
- Section settings button in the preview canvas

### 🎯 Why
Icon-only buttons lacked context for screen readers and visual tooltips. Furthermore, management actions (delete/settings) were only reachable via mouse hover, making them inaccessible to keyboard users.

### ♿ Accessibility
- Added localized `aria-label` and `title` attributes ('Vista de escritorio', 'Eliminar sección', etc.) for screen reader and visual support.
- Implemented `group-focus-within:opacity-100` on parent containers and `focus-visible:opacity-100` on buttons to ensure hover-only controls appear when navigated via keyboard.
- Applied the project's preferred `focus-visible` styles (`ring-2 focus-visible:ring-indigo-500`) to all interactive elements to provide clear visual feedback during navigation.

### 🛠️ Verification
- Verified with a Playwright script that labels are present and controls are visible on focus.
- Manual visual inspection of focus states.
- Ran `pnpm lint` and `pnpm build` to ensure no regressions.

---
*PR created automatically by Jules for task [6677686911481878019](https://jules.google.com/task/6677686911481878019) started by @satbmc*