### PR TITLE
🎨 Palette: Mejoras de accesibilidad y navegación por teclado

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-30 - Accesibilidad por teclado en editores visuales
+**Learning:** En herramientas de construcción visual (builders) donde las secciones son contenedores interactivos no semánticos, el uso de `group-focus-within` permite revelar controles que normalmente solo aparecen al pasar el ratón (como botones de configuración o eliminación) a los usuarios que navegan por teclado. Esto mantiene una interfaz limpia para usuarios de ratón sin comprometer la accesibilidad.
+**Action:** Aplicar siempre `tabIndex={0}`, `role="button"` y manejadores `onKeyDown` a los contenedores de secciones en el lienzo, y asegurar que sus botones de acción internos sean visibles mediante `group-focus-within:opacity-100` o clases similares cuando el contenedor recibe el foco.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>
@@ -630,8 +636,16 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
+                              tabIndex={0}
+                              role="button"
+                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                               onClick={() => setActiveSectionId(section.id)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  setActiveSectionId(section.id);
+                                }
+                              }}
                             >
                               <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
                                 {SECTION_TYPES.find(t => t.type === section.type)?.icon === 'Layout' && <Layout size={16} />}
@@ -648,7 +662,9 @@ export default function App() {
                               </span>
                               <button 
                                 onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                                aria-label="Eliminar sección"
+                                title="Eliminar sección"
+                                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
                               >
                                 <Trash2 size={14} />
                               </button>
@@ -973,12 +989,24 @@ export default function App() {
                     pageData.sections.map((section) => (
                       <div 
                         key={section.id} 
-                        className={`relative group ${activeSectionId === section.id ? 'ring-2 ring-indigo-500 ring-inset' : ''}`}
+                        tabIndex={0}
+                        role="button"
+                        className={`relative group focus-visible:outline-none ${activeSectionId === section.id ? 'ring-2 ring-indigo-500 ring-inset' : 'focus-visible:ring-2 focus-visible:ring-indigo-400 ring-inset'}`}
                         onClick={() => setActiveSectionId(section.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setActiveSectionId(section.id);
+                          }
+                        }}
                       >
                         {renderSectionPreview(section)}
-                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-2">
-                          <button className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600">
+                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex gap-2">
+                          <button
+                            aria-label="Configuración de sección"
+                            title="Configuración de sección"
+                            className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
+                          >
                             <Settings size={16} />
                           </button>
                         </div>


### PR DESCRIPTION
### 🎨 Palette: Mejoras de accesibilidad y navegación por teclado

Esta actualización se centra en hacer que el editor de LandingCraft sea completamente utilizable mediante el teclado y más accesible para usuarios de lectores de pantalla.

#### 💡 Cambios realizados:
- **Botones de vista previa:** Se añadieron etiquetas ARIA y títulos descriptivos ('Vista de escritorio', 'Vista de tableta', 'Vista de móvil') a los botones de cambio de dispositivo.
- **Navegación de secciones:** Tanto las secciones en la barra lateral como en el lienzo de previsualización ahora son enfocables mediante la tecla Tabulador y responden a las teclas 'Enter' y 'Espacio'.
- **Visibilidad inteligente:** Los botones de 'Eliminar' y 'Configuración', que anteriormente solo eran visibles al pasar el ratón, ahora aparecen automáticamente cuando su sección contenedora recibe el foco del teclado gracias al uso de `group-focus-within`.
- **Indicadores de foco:** Se implementaron anillos de enfoque claros utilizando `focus-visible:ring-indigo-500` para proporcionar una navegación visualmente coherente.

#### 🎯 Por qué:
Las herramientas de diseño visual a menudo olvidan a los usuarios que dependen del teclado. Estos cambios aseguran que todos los usuarios puedan seleccionar, editar y eliminar secciones sin necesidad de un ratón, manteniendo una estética limpia para los usuarios tradicionales.

#### ♿ Accesibilidad:
- Cumple con los estándares de roles semánticos (`role="button"`) para elementos no nativos.
- Localización completa de etiquetas ARIA en español.
- Mejora drástica del orden de tabulación y la visibilidad de estados interactivos.

---
*PR created automatically by Jules for task [10211391598299026418](https://jules.google.com/task/10211391598299026418) started by @satbmc*