### PR TITLE
🎨 Palette: Improve keyboard accessibility for section controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-22 - Improved Keyboard Accessibility for Section Controls
+**Learning:** In visual builder interfaces, hover-only controls (like Delete or Settings) must be made visible on keyboard focus to ensure the app is usable by all. Using Tailwind's `group-focus-within` on parent containers is an effective pattern to reveal these controls without cluttering the UI for mouse users.
+**Action:** Always check for `group-hover:opacity-100` patterns and supplement them with `group-focus-within:opacity-100` and ensure the parent container is keyboard-focusable with proper `role` and `tabIndex`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -630,7 +630,15 @@ export default function App() {
                               initial={{ opacity: 0, x: -10 }}
                               animate={{ opacity: 1, x: 0 }}
                               exit={{ opacity: 0, x: -10 }}
-                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
+                              role="button"
+                              tabIndex={0}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  setActiveSectionId(section.id);
+                                }
+                              }}
+                              className={`group flex items-center gap-3 p-3 rounded-xl border transition-all cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${activeSectionId === section.id ? 'bg-indigo-50 border-indigo-200 text-indigo-700' : 'bg-white border-slate-100 hover:border-slate-300 text-slate-600'}`}
                               onClick={() => setActiveSectionId(section.id)}
                             >
                               <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center shrink-0 group-hover:bg-white transition-colors">
@@ -648,7 +656,9 @@ export default function App() {
                               </span>
                               <button 
                                 onClick={(e) => { e.stopPropagation(); removeSection(section.id); }}
-                                className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all"
+                                aria-label="Eliminar sección"
+                                title="Eliminar sección"
+                                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 p-1.5 hover:bg-red-50 hover:text-red-600 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
                               >
                                 <Trash2 size={14} />
                               </button>
@@ -973,12 +983,24 @@ export default function App() {
                     pageData.sections.map((section) => (
                       <div 
                         key={section.id} 
-                        className={`relative group ${activeSectionId === section.id ? 'ring-2 ring-indigo-500 ring-inset' : ''}`}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setActiveSectionId(section.id);
+                          }
+                        }}
+                        className={`relative group focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${activeSectionId === section.id ? 'ring-2 ring-indigo-500 ring-inset' : ''}`}
                         onClick={() => setActiveSectionId(section.id)}
                       >
                         {renderSectionPreview(section)}
-                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity flex gap-2">
-                          <button className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600">
+                        <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex gap-2">
+                          <button
+                            aria-label="Configuración de sección"
+                            title="Configuración de sección"
+                            className="p-2 bg-white shadow-lg rounded-lg text-slate-600 hover:text-indigo-600 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
+                          >
                             <Settings size={16} />
                           </button>
                         </div>


### PR DESCRIPTION
This PR enhances the accessibility of the Landing Page Builder by making section controls reachable and visible via keyboard. 

Key changes:
- Section items in the sidebar and canvas are now focusable and can be selected using Enter or Space.
- Hover-only buttons (Trash and Settings) now appear when their parent section receives focus, thanks to `group-focus-within`.
- Added localized (Spanish) ARIA labels and titles to ensure screen reader compatibility.
- Implemented standard `focus-visible` rings for all interactive elements to provide clear visual feedback during keyboard navigation.
- Verified all changes using Playwright integration tests.

---
*PR created automatically by Jules for task [6180744623458554597](https://jules.google.com/task/6180744623458554597) started by @satbmc*