### PR TITLE
🎨 Palette: Improve accessibility of device preview buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Accessibility for Icon-only Buttons
+**Learning:** Icon-only buttons without text labels are inaccessible to screen reader users and lack visual context for sighted users without hover. Standardizing on `aria-label` and `title` for these elements significantly improves basic accessibility and provides helpful tooltips. Visible focus rings are also essential for keyboard users to identify their location in the editor.
+**Action:** Always include `aria-label`, `title`, and `focus-visible` ring styles when implementing icon-only buttons. Ensure ARIA labels are localized in the same language as the rest of the application interface.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,19 +382,25 @@ export default function App() {
             <div className="flex bg-slate-100 p-1 rounded-lg">
               <button 
                 onClick={() => setPreviewDevice('desktop')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de escritorio"
+                title="Vista de escritorio"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'desktop' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Monitor size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('tablet')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de tableta"
+                title="Vista de tableta"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'tablet' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Tablet size={18} />
               </button>
               <button 
                 onClick={() => setPreviewDevice('mobile')}
-                className={`p-1.5 rounded-md transition-all ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
+                aria-label="Vista de móvil"
+                title="Vista de móvil"
+                className={`p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${previewDevice === 'mobile' ? 'bg-white shadow-sm text-indigo-600' : 'text-slate-500 hover:text-slate-700'}`}
               >
                 <Smartphone size={18} />
               </button>


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the device preview buttons (Monitor, Tablet, Smartphone) in the editor header.

🎯 **Why:** These icon-only buttons lacked descriptive labels for screen readers and did not have visible focus indicators, making them difficult to use for users relying on assistive technology or keyboard navigation.

♿ **Accessibility:**
- Added `aria-label` and `title` attributes in Spanish to match the interface localization.
- Added Tailwind's `focus-visible:ring-2` to provide a clear visual indicator during keyboard navigation.
- Ensured consistency across the preview control group.

This micro-UX improvement enhances the inclusivity of the LandingCraft editor with minimal code changes.

---
*PR created automatically by Jules for task [400625204212969064](https://jules.google.com/task/400625204212969064) started by @satbmc*